### PR TITLE
fix CVE-2019-14274-05-gniibe-fix-13 and fix mcpp-man

### DIFF
--- a/mcpp-gcc.1
+++ b/mcpp-gcc.1
@@ -16,6 +16,8 @@ and \fI<outfile>\fR defaults to standard output.
 It takes the following options.
 .PP
 Commonly used options:
+.IP "\fB-$, -fno-dollars-in-identifiers"
+Forbid '$' in identifiers.
 .IP \fB-@MODE
 Specify preprocessing mode. MODE should be one of these 4:
 .IP "    \fB-@std"
@@ -26,6 +28,8 @@ special 'post-Standard' mode.
 K&R 1st mode.
 .IP "    \fB-@oldprep, -@old"
 "old_preprocessor" mode (i.e. "Reiser model" cpp).
+.IP "    \fB-@compat"
+Standard 'compatible' mode.
 .IP \fB-b
 Output #line lines in C source style (default: GCC style).
 .IP \fB-C
@@ -34,21 +38,43 @@ Output also comments.
 Define <macro> as <value> (default:1).
 .IP "\fB-D <macro(args)>[=<replace>]"
 Define <macro(args)> as <replace>.
+.IP "\fB-dM, -dD"
+Dump all current macro definitions to output stream.
 .IP "\fB-e <encoding>"
 Change the default multi-byte character encoding to one of:
 euc_jp, gb2312, ksc5601, big5, sjis, iso2022_jp, utf8.
 .IP \fB-finput-charset=<encoding>
 Same as -e <encoding>.  (Do not insert spaces around '=').
+.IP \fB-f[no-]working-directory
+(Don't) emit #line marks with current working directory.
+.IP \fB-fstack-protector[-all]
+Add defines for GCC stack protector.
+.IP \fB-f[no-]exceptions
+(Don't) add define for exception support.
+.IP "\fB-fpic, -fPIC, -fpie, -fPIE"
+Add defines for PIC/PIE code.
 .IP "\fB-I <directory>"
 Add <directory> to the #include search list.
 .IP \fB-I-
 Unset system or site specific include directories.
 .IP "\fB-include <file>"
 Include the <file> prior to the main input file.
+.IP "\fB-isystem <dir>"
+Look for include files in DIR, if not found in -I's.
+.IP "\fB-iquote <dir>"
+Look for #include "file" (with quotes) in DIR.
 .IP \fB-j
 Do not output the source line in diagnostics.
+.IP \fB-k
+Keep white spaces of input lines as they are.
 .IP "\fB-M, -MM, -MD, -MMD, -MP, -MQ target, -MT target, -MF file"
 Output source file dependency line for makefile.
+.IP \fB-m32
+Change target CPU from x86_64, ppc64 to i386, ppc, respectively.
+.IP \fB-m64
+Change target CPU from i386, ppc to x86_64, ppc64, respectively.
+.IP \fB-[no-]mmx
+(Un-)define __MMX__.
 .IP \fB-N
 Don't predefine any non-standard macros.
 .IP \fB-nostdinc
@@ -83,8 +109,12 @@ Enable digraphs.
 Re-define the pre-defined macro __STDC_HOSTED__ as <n>.
 .IP \fB-lang-c89
 Same as -S1.
+.IP "\fB-lang-c99, -lang-c9x"
+Same as -S199901L.
 .IP \fB-lang-c++
 Same as -+.
+.IP \fB-lang-asm
+Same as -a.
 .IP "\fB-pedantic, -pedantic-errors"
 Same as -W7.
 .IP "\fB-S <n>"

--- a/mcpp.1
+++ b/mcpp.1
@@ -26,6 +26,8 @@ special 'post-Standard' mode.
 K&R 1st mode.
 .IP "    \fB-@oldprep, -@old"
 "old_preprocessor" mode (i.e. "Reiser model" cpp).
+.IP "    \fB-@compat"
+Standard 'compatible' mode.
 .IP \fB-C
 Output also comments.
 .IP "\fB-D <macro>[=<value>]"
@@ -41,8 +43,16 @@ Add <directory> to the #include search list.
 Unset system or site specific include directories.
 .IP \fB-j
 Do not output the source line in diagnostics.
+.IP \fB-k
+Keep white spaces of input lines as they are.
 .IP "\fB-M, -MM, -MD, -MMD, -MP, -MQ target, -MT target, -MF file"
 Output source file dependency line for makefile.
+.IP \fB-m32
+Change target CPU from x86_64, ppc64 to i386, ppc, respectively.
+.IP \fB-m64
+Change target CPU from i386, ppc to x86_64, ppc64, respectively.
+.IP \fB-[no-]mmx
+(Un-)define __MMX__.
 .IP \fB-N
 Don't predefine any non-standard macros.
 .IP "\fB-o <file>"

--- a/src/support.c
+++ b/src/support.c
@@ -822,7 +822,7 @@ escape:
         if (diag && iscntrl( c) && ((char_type[ c] & SPA) == 0)
                 && (warn_level & 1))
             cwarn(
-            "Illegal control character %.0s0lx%02x in quotation"    /* _W1_ */
+            "Illegal control character %.0s0x%02x in quotation"    /* _W1_ */
                     , NULL, (long) c, NULL);
         *out_p++ = c;
 chk_limit:
@@ -861,10 +861,10 @@ chk_limit:
                 if (mcpp_mode != POST_STD && option_flags.lang_asm) {
                     /* STD, KR      */
                     if (warn_level & 1)
-                        cwarn( unterm_char, out, 0L, NULL); /* _W1_ */
+                        cwarn( unterm_char, NULL, (long)delim, NULL); /* _W1_ */
                     goto  done;
                 } else {
-                    cerror( unterm_char, out, 0L, skip);    /* _E_  */
+                    cerror( unterm_char, NULL, (long)delim, skip);    /* _E_  */
                 }
             } else {
                 cerror( "Unterminated header name %s%.0ld%s"        /* _E_  */
@@ -875,9 +875,9 @@ chk_limit:
             if (mcpp_mode != POST_STD && option_flags.lang_asm) {
                 /* STD, KR      */
                 if (warn_level & 1)
-                    cwarn( empty_const, out, 0L, skip);     /* _W1_ */
+                    cwarn( empty_const, NULL, (long)delim, skip);     /* _W1_ */
             } else {
-                cerror( empty_const, out, 0L, skip);        /* _E_  */
+                cerror( empty_const, NULL, (long)delim, skip);        /* _E_  */
                 out_p = NULL;
                 goto  done;
             }
@@ -1772,7 +1772,7 @@ not_comment:
         default:
             if (iscntrl( c)) {
                 cerror(             /* Skip the control character   */
-    "Illegal control character %.0s0x%lx, skipped the character"    /* _E_  */
+    "Illegal control character %.0s0x%02x, skipped the character"    /* _E_  */
                         , NULL, (long) c, NULL);
             } else {                        /* Any valid character  */
                 *tp++ = c;

--- a/src/system.c
+++ b/src/system.c
@@ -1418,11 +1418,16 @@ static void usage(
 
 "\nCommonly used options:\n",
 
+#if COMPILER == GNUC
+"-$                           Forbid '$' in identifier.\n",
+"-fno-dollars-in-identifiers  Likewise.\n",
+#endif
 "-@MODE      Specify preprocessing mode. MODE should be one of these 4:\n",
 "    -@std               Standard conforming mode. (default)\n",
 "    -@poststd, -@post   special 'post-Standard' mode.\n",
 "    -@kr                K&R 1st mode.\n",
 "    -@oldprep, -@old    'old_preprocessor' mode (i.e. 'Reiser model' cpp).\n",
+"    -@compat            Standard 'compatible' mode.\n",
 
 #if COMPILER == MSC
 "-arch:SSE, -arch:SSE2   Define the macro _M_IX86_FP as 1, 2 respectively.\n",
@@ -1438,6 +1443,9 @@ static void usage(
 "-C          Output also comments.\n",
 "-D <macro>[=<value>]    Define <macro> as <value> (default:1).\n",
 "-D <macro(args)>[=<replace>]    Define <macro(args)> as <replace>.\n",
+#if COMPILER == GNUC
+"-dM,-dD     Dump all current macro definitions to output stream.\n",
+#endif
 "-e <encoding>   Change the default multi-byte character encoding to one of:\n",
 "            euc_jp, gb2312, ksc5601, big5, sjis, iso2022_jp, utf8.\n",
 
@@ -1447,6 +1455,11 @@ static void usage(
 #if COMPILER == GNUC
 "-finput-charset=<encoding>      Same as -e <encoding>.\n",
 "            (Don't insert spaces around '=').\n",
+"-f[no-]working-directory      (Don't) emit #line marks with current\n",
+"                              working directory.\n",
+"-fstack-protector[-all]       Add defines for GCC stack protector.\n",
+"-f[no-]exceptions             (Don't) add define for exception support.\n",
+"-fpic,-fPIC,-fpie,-fPIE       Add defines for PIC/PIE code.\n"
 #endif
 #if COMPILER == MSC
 "-Fl <file>  Include the <file> prior to the main input file.\n",
@@ -1461,6 +1474,8 @@ static void usage(
 #if COMPILER == GNUC
 "-isysroot <dir>     Change root of system header directory to <dir>.\n",
 "-include <file>     Include the <file> prior to the main input file.\n",
+"-isystem <dir>      Look for include files in DIR, if not found in -I's.\n",
+"-iquote <dir>       Look for #include \"file\" (with quotes) in DIR.\n",
 #else
 "-I-         Unset system or site specific include directories.\n",
 #endif
@@ -1474,6 +1489,7 @@ static void usage(
 #if SYS_FAMILY == SYS_UNIX
 "-m32        Change target CPU from x86_64, ppc64 to i386, ppc, respectively.\n",
 "-m64        Change target CPU from i386, ppc to x86_64, ppc64, respectively.\n",
+"-[no-]mmx   (Un-)define __MMX__.\n",
 #endif
 "-N          Don't predefine any non-standard macros.\n",
 
@@ -1536,7 +1552,10 @@ static void usage(
 
 #if COMPILER == GNUC
 "-lang-c89   Same as -S1.\n",
+"-lang-c99   Same as -S199901L.\n",
+"-lang-c9x   Likewise.\n",
 "-lang-c++   Same as -+.\n",
+"-lang-asm   Same as -a.\n",
 "-pedantic, -pedantic-errors     Same as -W7.\n",
 "-S <n>      Redefine __STDC__ to <n>.\n",
 #else


### PR DESCRIPTION
fix CVE-2019-14274
Reference:https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/mcpp/2.7.2-5/mcpp_2.7.2-5.debian.tar.xz
Conflict:NA
fix mcpp-man
Reference:https://src.fedoraproject.org/rpms/mcpp/blob/master/f/mcpp-man.patch
Conflict:NA