### PR TITLE
Fix heap-based buffer overflow in the do_msg function

### DIFF
--- a/src/support.c
+++ b/src/support.c
@@ -822,7 +822,7 @@ escape:
         if (diag && iscntrl( c) && ((char_type[ c] & SPA) == 0)
                 && (warn_level & 1))
             cwarn(
-            "Illegal control character %.0s0lx%02x in quotation"    /* _W1_ */
+            "Illegal control character %.0s0x%02x in quotation"    /* _W1_ */
                     , NULL, (long) c, NULL);
         *out_p++ = c;
 chk_limit:
@@ -861,10 +861,10 @@ chk_limit:
                 if (mcpp_mode != POST_STD && option_flags.lang_asm) {
                     /* STD, KR      */
                     if (warn_level & 1)
-                        cwarn( unterm_char, out, 0L, NULL); /* _W1_ */
+                        cwarn( unterm_char, NULL, (long)delim, NULL); /* _W1_ */
                     goto  done;
                 } else {
-                    cerror( unterm_char, out, 0L, skip);    /* _E_  */
+                    cerror( unterm_char, NULL, (long)delim, skip);    /* _E_  */
                 }
             } else {
                 cerror( "Unterminated header name %s%.0ld%s"        /* _E_  */
@@ -875,9 +875,9 @@ chk_limit:
             if (mcpp_mode != POST_STD && option_flags.lang_asm) {
                 /* STD, KR      */
                 if (warn_level & 1)
-                    cwarn( empty_const, out, 0L, skip);     /* _W1_ */
+                    cwarn( empty_const, NULL, (long)delim, skip);     /* _W1_ */
             } else {
-                cerror( empty_const, out, 0L, skip);        /* _E_  */
+                cerror( empty_const, NULL, (long)delim, skip);        /* _E_  */
                 out_p = NULL;
                 goto  done;
             }
@@ -1772,7 +1772,7 @@ not_comment:
         default:
             if (iscntrl( c)) {
                 cerror(             /* Skip the control character   */
-    "Illegal control character %.0s0x%lx, skipped the character"    /* _E_  */
+    "Illegal control character %.0s0x%02x, skipped the character"    /* _E_  */
                         , NULL, (long) c, NULL);
             } else {                        /* Any valid character  */
                 *tp++ = c;


### PR DESCRIPTION
Fix #4 
Heap-based buffer overflow in the do_msg() function in support.c
Synchronous modification from https://gitee.com/src-openeuler/mcpp/commit/426dd5b245ccfb682f90023c09a9b6b06c6843b2